### PR TITLE
Amélioration de la récupération des informations depuis apcaccess

### DIFF
--- a/core/class/apcups.class.php
+++ b/core/class/apcups.class.php
@@ -77,7 +77,7 @@ class apcups extends eqLogic {
 
   public function preUpdate() {
     if ($this->getConfiguration('addr') == '') {
-      throw new Exception(__('L\adresse ne peut etre vide',__FILE__));
+      throw new Exception(__('L\'adresse ne peut etre vide',__FILE__));
     }
     if ($this->getConfiguration('port') == '') {
       throw new Exception(__('Le port ne peut etre vide',__FILE__));

--- a/core/i18n/fr_FR.json
+++ b/core/i18n/fr_FR.json
@@ -24,7 +24,9 @@
         "Paramètres": "Paramètres"
     },
     "plugins\/apcups\/desktop\/js\/apcups.js": {
-        "Historiser": "Historiser"
+        "Historiser": "Historiser",
+        "Nom de la commande": "Nom de la commande",
+        "Tester": "Tester"
     },
     "plugins\/apcups\/core\/class\/apcups.class.php": {
         "Statut": "Statut",
@@ -36,6 +38,11 @@
         "% Charge": "% Charge",
         "Batterie": "Batterie",
         "Puissance fournie": "Puissance fournie",
-        "L\\adresse ne peut etre vide": "L\\adresse ne peut etre vide"
+        "Apcupsd": "Apcupsd",
+        "NOK": "NOK",
+        "Indique si le service apcupsd est démarré": "Indique si le service apcupsd est démarré",
+        "The command": "La commande",
+        "has failed or not returned any string.": "a echouée ou n'a pas retournée de résultat.",
+        "L'adresse ne peut etre vide": "L'adresse ne peut etre vide"
     }
 }


### PR DESCRIPTION
Bonjour,

J'ai retravaillé un petit peu la fonction de récupération d'informations et de parsing de la commande 'apcaccess'. Maintenant, elle ne s'execute qu'une seule fois pour toutes les commandes. Ceci permet de limiter le nombre de fork du kernel.
Je me suis permis de corrigé un petit bug dans le reporting du statut de la battery à Jeedom, maintenant le pourcentage de batterie remonte bien dans l'écran "Batteries"

Cdlt