### PR TITLE
Correction du problème de remonté des 'event'

### DIFF
--- a/core/class/apcups.class.php
+++ b/core/class/apcups.class.php
@@ -272,7 +272,8 @@ class apcups extends eqLogic {
       $key = strtoupper($cmd->getLogicalId());
       switch ($cmd->getLogicalId()) {
         case 'event':
-          continue;
+          log::add('apcups', 'debug', ' => ignore');
+          continue 2;
         case 'model':
           if (isset($informations[$key])) {
             $value = $informations[$key]['raw'];

--- a/core/class/apcups.class.php
+++ b/core/class/apcups.class.php
@@ -232,7 +232,7 @@ class apcups extends eqLogic {
 
   /**
    * Fetch new informations from apcups daemon
-   * 
+   *
    * @return array of information
    *     each key of this array is composed of the following sub keys
    *        - raw : the raw value from apcaccess
@@ -277,16 +277,16 @@ class apcups extends eqLogic {
       ];
       log::add('apcups', 'debug', "Get information key $key with value $value");
 	}
-    
+
     return $informations;
   }
-  
+
   /**
    * Update all command of this equipment with new informations
    */
   protected function updateCommands() {
 	$informations = $this->getInformations();
-    
+
     # loop for each command and update its infos
     foreach ($this->getCmd('info') as $cmd) {
       $key = strtoupper($cmd->getLogicalId());

--- a/core/class/apcups.class.php
+++ b/core/class/apcups.class.php
@@ -281,16 +281,19 @@ class apcups extends eqLogic {
     # loop for each command and update its infos
     foreach ($this->getCmd('info') as $cmd) {
       $key = strtoupper($cmd->getLogicalId());
+      log::add('apcups', 'debug', 'Update command ' . $cmd->getLogicalId());
       switch ($cmd->getLogicalId()) {
         case 'event':
           log::add('apcups', 'debug', ' => ignore');
           continue 2;
         case 'model':
+          log::add('apcups', 'debug', ' => apply model case');
           if (isset($informations[$key])) {
             $value = $informations[$key]['raw'];
           }
           break;
         case 'outpower':
+          log::add('apcups', 'debug', ' => apply outpower case');
           if (isset($puissance) && isset($informations['LOADPCT'])) {
             $value = $puissance * $informations['LOADPCT']['float'] / 100 * 0.66;
           } else {
@@ -298,6 +301,7 @@ class apcups extends eqLogic {
           }
           break;
         default:
+          log::add('apcups', 'debug', ' => apply default case');
           if (isset($informations[$key])) {
             if ($cmd->getSubType() == 'numeric') {
               $value = $informations[$key]['float'];
@@ -308,10 +312,11 @@ class apcups extends eqLogic {
           break;
       }
 
-      log::add('apcups', 'debug', $cmd->getLogicalId() . ' : ' . $value);
       if($cmd->getLogicalId() == 'bcharge') {
+        log::add('apcups', 'debug', ' => update battery status');
         $this->batteryStatus($value);
       }
+      log::add('apcups', 'debug', ' => update command ' . $cmd->getLogicalId() . ' with ' . $value);
       $this->checkAndUpdateCmd($cmd->getLogicalId(), $value);
     }
 

--- a/core/class/apcups.class.php
+++ b/core/class/apcups.class.php
@@ -310,12 +310,13 @@ class apcups extends eqLogic {
     $hostname = init('hostname');
     $event = init('event');
     $ip = getClientIp();
-    echo $ip;
-    log::add('apcups', 'info', 'event ' . $event . ' pour ' . $hostname . ' de ' . $ip);
+    log::add('apcups', 'info', "reçu event '$event' pour '$hostname' de '$ip'");
     $elogic = self::byLogicalId($hostname, 'apcups');
     if (is_object($elogic)) {
-      $this->checkAndUpdateCmd('event', $event);
-      log::add('apcups', 'info', 'event ' . $event . ' pour ' . $hostname . ' de ' . $ip);
+      $elogic->checkAndUpdateCmd('event', $event);
+      log::add('apcups', 'info', "mise à jour event '$event' pour '$hostname' de $ip");
+    } else {
+      log::add('apcups', 'warning', "echec de mise à jour event '$event' pour '$hostname' de $ip : $hostname introuvable");
     }
   }
 

--- a/core/class/apcups.class.php
+++ b/core/class/apcups.class.php
@@ -230,6 +230,17 @@ class apcups extends eqLogic {
     return $this->postToHtml($_version, template_replace($replace, getTemplate('core', $version, 'apcups', 'apcups')));
   }
 
+  /**
+   * Fetch new informations from apcups daemon
+   * 
+   * @return array of information
+   *     each key of this array is composed of the following sub keys
+   *        - raw : the raw value from apcaccess
+   *        - integer : the first integer value available or null
+   *        - float : the first float available or null
+   *        - word : the first word available, it's the first piece
+   *             of letters before the first space or the end of line
+   */
   public function getInformations() {
     $addr = $this->getConfiguration('addr', '127.0.0.1');
     $port = $this->getConfiguration('port', 3551);

--- a/core/class/apcups.class.php
+++ b/core/class/apcups.class.php
@@ -296,7 +296,7 @@ class apcups extends eqLogic {
           break;
       }
 
-      log::add('apcups', 'debug', $command . ' : ' . $value);
+      log::add('apcups', 'debug', $cmd->getLogicalId() . ' : ' . $value);
       if($cmd->getLogicalId() == 'bcharge') {
         $this->batteryStatus($value);
       }

--- a/core/class/apcups.class.php
+++ b/core/class/apcups.class.php
@@ -71,7 +71,7 @@ class apcups extends eqLogic {
 
   public static function pull() {
     foreach (eqLogic::byType('apcups',true) as $apcups) {
-      $apcups->getInformations();
+      $apcups->updateCommands();
     }
   }
 
@@ -204,7 +204,7 @@ class apcups extends eqLogic {
     $apcupsCmd->setDisplay('generic_type','POWER');
     $apcupsCmd->save();
 
-    $this->getInformations();
+    $this->updateCommands();
 
   }
 
@@ -277,7 +277,16 @@ class apcups extends eqLogic {
       ];
       log::add('apcups', 'debug', "Get information key $key with value $value");
 	}
-
+    
+    return $informations;
+  }
+  
+  /**
+   * Update all command of this equipment with new informations
+   */
+  protected function updateCommands() {
+	$informations = $this->getInformations();
+    
     # loop for each command and update its infos
     foreach ($this->getCmd('info') as $cmd) {
       $key = strtoupper($cmd->getLogicalId());

--- a/doc/fr_FR/changelog.asciidoc
+++ b/doc/fr_FR/changelog.asciidoc
@@ -1,3 +1,17 @@
+==== Version 2017-06-15
+
+* Fonctionnalités
+
+** Ajout de la remonté du niveau de batterie de l'onduleur dans la page "Batteries" de Jeedom
+
+* Améliorations
+
+** Refonte du système de lecture des valeurs de l'onduleur
+
+* Bug Fixes
+
+** Correction d'un bug de remonté des events
+
 ==== Version 1.1
 
 Passage au système de dépendances 2.0


### PR DESCRIPTION
Bonjour Lunarok

Je viens de corriger un bug sur la remonté des evenements du service apcupsd signalé par le post https://www.jeedom.com/forum/viewtopic.php?f=144&t=6598&p=471508&hilit=apcupsd#p478021
J'ai également trouvé un bug dans mon code précédemant soumis via la PR #2 .
Par précaution j'ai ajouté de nombreux message de debug à des points clés du code. Et j'ai séparé la fonction qui recupère et parse les informations de la commande apcaccess de celle qui met à jour les commandes. De sorte de faciliter la maintenance.

Le correctif est testé chez moi, tout fonctionne.

