### PR TITLE
fix cmd subtype, add display options, fix icon

### DIFF
--- a/core/class/apcups.class.php
+++ b/core/class/apcups.class.php
@@ -95,7 +95,7 @@ class apcups extends eqLogic {
       $apcupsCmd->setEqLogic_id($this->id);
       $apcupsCmd->setLogicalId('status');
       $apcupsCmd->setType('info');
-      $apcupsCmd->setSubType('other');
+      $apcupsCmd->setSubType('string');
       $apcupsCmd->save();
     }
 
@@ -107,7 +107,7 @@ class apcups extends eqLogic {
       $apcupsCmd->setEqLogic_id($this->id);
       $apcupsCmd->setLogicalId('event');
       $apcupsCmd->setType('info');
-      $apcupsCmd->setSubType('other');
+      $apcupsCmd->setSubType('string');
       $apcupsCmd->save();
     }
 
@@ -158,7 +158,7 @@ class apcups extends eqLogic {
       $apcupsCmd->setEqLogic_id($this->id);
       $apcupsCmd->setLogicalId('model');
       $apcupsCmd->setType('info');
-      $apcupsCmd->setSubType('other');
+      $apcupsCmd->setSubType('string');
       $apcupsCmd->save();
     }
 

--- a/desktop/js/apcups.js
+++ b/desktop/js/apcups.js
@@ -25,11 +25,24 @@ function addCmdToTable(_cmd) {
       var tr = '<tr class="cmd" data-cmd_id="' + init(_cmd.id) + '">';
       tr += '<td>';
       tr += '<span class="cmdAttr" data-l1key="id"></span>';
+      tr += '<input class="cmdAttr form-control input-sm" data-l1key="type" style="display : none;">';
+      tr += '<input class="cmdAttr form-control input-sm" data-l1key="subType" style="display : none;">';
       tr += '</td><td>';
+      tr += '<div class="col-sm-3">';
+      tr += '<a class="cmdAction btn btn-default btn-sm" data-l1key="chooseIcon"><i class="fas fa-flag"></i> Icône</a>';
+      tr += '<span class="cmdAttr" data-l1key="display" data-l2key="icon" style="margin-left : 10px;"></span>';
+      tr += '</div>';
+      tr += '<div class="col-sm-4">';
       tr += '<input class="cmdAttr form-control input-sm" data-l1key="name" style="width : 140px;" placeholder="{{Nom de la commande}}"></td>';
+      tr += '</div>';
       tr += '</td><td>';
-      if (_cmd.subType == 'numeric' || _cmd.subType == 'binary') {
-        tr += '<span><label class="checkbox-inline"><input type="checkbox" class="cmdAttr checkbox-inline" data-l1key="isHistorized" checked/>{{Historiser}}</label></span>';
+      tr += '<span><label class="checkbox-inline"><input type="checkbox" class="cmdAttr checkbox-inline" data-l1key="isHistorized" checked/>{{Historiser}}</label></span> ';
+      tr += '<span><label class="checkbox-inline"><input type="checkbox" class="cmdAttr checkbox-inline" data-l1key="isVisible" />{{Afficher}}</label></span> ';
+      tr += '</td><td>';
+      if (_cmd.subType == 'numeric') {
+        tr += '<input class="cmdAttr form-control input-sm" data-l1key="unite" placeholder="Unité" title="{{Unité}}">';
+        tr += '<input class="cmdAttr form-control input-sm" data-l1key="configuration" data-l2key="minValue" placeholder="{{Min}}" title="{{Min}}" style="margin-top : 5px;"> ';
+        tr += '<input class="cmdAttr form-control input-sm" data-l1key="configuration" data-l2key="maxValue" placeholder="{{Max}}" title="{{Max}}" style="margin-top : 5px;">';
       }
       tr += '</td><td>';
       if (is_numeric(_cmd.id)) {

--- a/desktop/php/apcups.php
+++ b/desktop/php/apcups.php
@@ -38,7 +38,7 @@ $eqLogics = eqLogic::byType('apcups');
         $opacity = ($eqLogic->getIsEnable()) ? '' : jeedom::getConfiguration('eqLogic:style:noactive');
         echo '<div class="eqLogicDisplayCard cursor" data-eqLogic_id="' . $eqLogic->getId() . '" style="background-color : #ffffff ; height : 200px;margin-bottom : 10px;padding : 5px;border-radius: 2px;width : 160px;margin-left : 10px;' . $opacity . '" >';
         echo "<center>";
-        echo '<img src="plugins/apcups/doc/images/APC-UPS_icon.png" height="105" width="95" />';
+        echo '<img src="' . $eqLogic->getImage() . '" height="105" width="95" />';
         echo "</center>";
         echo '<span style="font-size : 1.1em;position:relative; top : 15px;word-break: break-all;white-space: pre-wrap;word-wrap: break-word;"><center>' . $eqLogic->getHumanName(true, true) . '</center></span>';
         echo '</div>';
@@ -53,7 +53,7 @@ $eqLogics = eqLogic::byType('apcups');
  <a class="btn btn-default eqLogicAction pull-right" data-action="configure"><i class="fas fa-cogs"></i> {{Configuration avancée}}</a>
  <ul class="nav nav-tabs" role="tablist">
   <li role="presentation"><a href="#" class="eqLogicAction" aria-controls="home" role="tab" data-toggle="tab" data-action="returnToThumbnailDisplay"><i class="fas fa-arrow-circle-left"></i></a></li>
-  <li role="presentation" class="active"><a href="#eqlogictab" aria-controls="home" role="tab" data-toggle="tab"><i class="fas fa-tachometer"></i> {{Equipement}}</a></li>
+  <li role="presentation" class="active"><a href="#eqlogictab" aria-controls="home" role="tab" data-toggle="tab"><i class="fas fa-tachometer-alt"></i> {{Equipement}}</a></li>
   <li role="presentation"><a href="#commandtab" aria-controls="profile" role="tab" data-toggle="tab"><i class="fas fa-list-alt"></i> {{Commandes}}</a></li>
 </ul>
 <div class="tab-content" style="height:calc(100% - 50px);overflow:auto;overflow-x: hidden;">
@@ -131,6 +131,7 @@ $eqLogics = eqLogic::byType('apcups');
               <th style="width: 50px;">#</th>
               <th style="width: 300px;">{{Nom}}</th>
               <th style="width: 200px;">{{Paramètres}}</th>
+              <th style="width: 100px;">{{Options}}</th>
               <th style="width: 100px;"></th>
             </tr>
           </thead>

--- a/plugin_info/.htaccess
+++ b/plugin_info/.htaccess
@@ -1,0 +1,5 @@
+Order allow,deny
+<Files ~ "\.(jpg|jpeg|png|gif|pdf|txt|bmp)$">
+   allow from all
+</Files>
+Deny from all

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -28,6 +28,15 @@ function apcups_update() {
     if (is_object($cron)) {
         $cron->remove();
     }
+
+    try {
+        foreach (cmd::byTypeSubType('info', 'other') as $cmd) {
+            $cmd->setSubType('string');
+            $cmd->save();
+        }
+    } catch (Exception $e) {
+        log::add('apcups', 'error', $e->getMessage());
+    }
 }
 
 function apcups_remove() {


### PR DESCRIPTION
- fix info command "string" having type "other" (while it should be "string") + a loop on plugin update to migrate existing commands (info is not displayed on the widget if not done)
- fix plugin icon pointing to plugins/apcups/doc/images/ (this folder does not exist on new install)
- fix device tab icon "fas fa-tachometer" (which does not exists) to "fas fa-tachometer-alt"

as tohtml customization is gone, some options were missing for commands
- allow user to display or not a command
- allow user to select a icon for the command
- display units
with this the previous widget can be reproduced with standard jeedom features