### PR TITLE
Update apcups.class.php

### DIFF
--- a/core/class/apcups.class.php
+++ b/core/class/apcups.class.php
@@ -295,13 +295,14 @@ class apcups extends eqLogic {
           }
           break;
       }
-
-      if ($cmd->getLogicalId() == 'bcharge') {
-        log::add('apcups', 'debug', ' => update battery status');
-        $this->batteryStatus($value);
+      if (isset($value)) { // php8 compatibility
+        if ($cmd->getLogicalId() == 'bcharge') {
+          log::add('apcups', 'debug', ' => update battery status');
+          $this->batteryStatus($value);
+        }
+        log::add('apcups', 'debug', ' => update command ' . $cmd->getLogicalId() . ' with ' . $value);
+        $this->checkAndUpdateCmd($cmd->getLogicalId(), $value);
       }
-      log::add('apcups', 'debug', ' => update command ' . $cmd->getLogicalId() . ' with ' . $value);
-      $this->checkAndUpdateCmd($cmd->getLogicalId(), $value);
     }
 
     $this->refreshWidget();


### PR DESCRIPTION
to prevent
0029|PHP Warning:  Undefined variable $value in /var/www/html/plugins/apcups/core/class/apcups.class.php on line 301
0030|PHP Warning:  Undefined variable $value in /var/www/html/plugins/apcups/core/class/apcups.class.php on line 303
0031|PHP Warning:  Undefined variable $value in /var/www/html/plugins/apcups/core/class/apcups.class.php on line 304